### PR TITLE
Fix lint error

### DIFF
--- a/src/app/components/Question/index.tsx
+++ b/src/app/components/Question/index.tsx
@@ -129,7 +129,7 @@ class QuestionInner extends React.Component<IProps, IState> {
       .catch(() => {
         this.setState({
           saving: false,
-          saveError: "Failed to save your answer",
+          saveError: 'Failed to save your answer',
         });
       });
   }


### PR DESCRIPTION
One of string attributes was using " instead of ', added in #355. This has now been fixed
and the project can build successfully.