### PR TITLE
Reposition incomplete indicator for record

### DIFF
--- a/src/app/components/RecordList/index.tsx
+++ b/src/app/components/RecordList/index.tsx
@@ -78,8 +78,8 @@ class RecordListInner extends React.Component<IProp, any> {
     return [(
       <Table.Row key={r.id}>
         <Table.Cell>
-          {incomplete}
           {getHumanisedDate(new Date(r.conducted))}
+          {incomplete}
         </Table.Cell>
         <Table.Cell>{r.outcomeSet.name}</Table.Cell>
         <Table.Cell>{renderArray(this.renderTag, r.tags)}</Table.Cell>


### PR DESCRIPTION
The incomplete icon appears to the left of the date, which misaligns the
date with the ones which are complete. This change moves the icon to the
right to show better alignment in the column.