### PR TITLE
Beneficiary users see "thanks" screen after questionnaire

### DIFF
--- a/src/app/containers/Meeting/index.tsx
+++ b/src/app/containers/Meeting/index.tsx
@@ -17,6 +17,8 @@ import {isNullOrUndefined} from 'util';
 import {IOutcomeSet} from 'models/outcomeSet';
 import {Screen, IMeetingState, getPreviousState, canGoBack, getNextState, initialState} from './state-machine';
 import {journey} from 'helpers/url';
+import {isBeneficiaryUser} from '../../helpers/auth';
+import {Thanks} from './thanks';
 const { connect } = require('react-redux');
 
 interface IProps extends IURLConnector {
@@ -87,7 +89,14 @@ class MeetingInner extends React.Component<IProps, IState> {
   }
 
   private completed() {
-    journey(this.props.setURL, this.props.data.getMeeting.beneficiary, this.props.data.getMeeting.outcomeSetID);
+    if(isBeneficiaryUser()) {
+      this.setMeetingState({
+        screen: Screen.THANKS,
+        qIdx: this.currentQuestionIdx(),
+      });
+    } else {
+      journey(this.props.setURL, this.props.data.getMeeting.beneficiary, this.props.data.getMeeting.outcomeSetID);
+    }
   }
 
   private hasInstructions() {
@@ -200,6 +209,9 @@ class MeetingInner extends React.Component<IProps, IState> {
     }
     if (this.state.screen === Screen.INSTRUCTIONS) {
       return wrapper(this.renderInstructions(), this.renderProgressBar());
+    }
+    if (this.state.screen === Screen.THANKS) {
+      return wrapper(<Thanks />);
     }
     const currentQuestionID = this.state.currentQuestion;
     if (currentQuestionID === undefined) {

--- a/src/app/containers/Meeting/state-machine.ts
+++ b/src/app/containers/Meeting/state-machine.ts
@@ -3,6 +3,7 @@ export enum Screen {
   NOTES,
   REVIEW,
   INSTRUCTIONS,
+  THANKS,
 }
 
 export interface IMeetingState {

--- a/src/app/containers/Meeting/thanks.tsx
+++ b/src/app/containers/Meeting/thanks.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react';
+
+export const Thanks = () => (
+  <div>
+    <h1>Thank you</h1>
+    <span>We have successfully saved your answers</span>
+  </div>
+);


### PR DESCRIPTION
Limits what they see afterwards, saved problems with restricting navigation and having beneficiaries interpreting the results in the visualisations.

Closes #340 