### PR TITLE
Fix deploy command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,10 +53,11 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: app
+          path: dist
       - name: Deploy app to S3
         uses: reggionick/s3-deploy@v3
         with:
-          folder: app
+          folder: dist
           bucket: ${{ secrets.S3_BUCKET }}
           bucket-region: ${{ secrets.S3_BUCKET_REGION }}
           dist-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}


### PR DESCRIPTION
The s3 deploy step was failing and it is likely due to the fact that we expected the download artifacts to extract the files into a new folder. However, it was extracting to the root directory. The fix for this is to download the artifact into a given folder (provided by the `path` value) and then use that.

Close #579 