### PR TITLE
Refine workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,31 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 11.10.0
+      - name: Install dependencies
+        run: npm ci
+      - name: Run Linter
+        run: npm run lint
+      - name: Run Tests
+        run: npm test
+      - name: Generate Production Files
+        run: npm run build
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-debug
+          path: build
+  build-prod:
+    name: Build Production App
+    if: github.ref == 'refs/heads/master'
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
       - name: Remove previous branding folder
         run: rm -rf ./src/branding
       - name: Checkout branding repository
@@ -29,21 +54,17 @@ jobs:
           node-version: 11.10.0
       - name: Install dependencies
         run: npm ci
-      - name: Run Linter
-        run: npm run lint
-      - name: Run Tests
-        run: npm test
       - name: Generate Production Files
         run: npm run build:prod
       - name: Upload build artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: app
+          name: build-prod
           path: build
   deploy:
     name: Deploy App
     if: github.ref == 'refs/heads/master'
-    needs: build-and-test
+    needs: build-prod
     runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -52,7 +73,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: app
+          name: build-prod
           path: dist
       - name: Deploy app to S3
         uses: reggionick/s3-deploy@v3
@@ -63,5 +84,4 @@ jobs:
           dist-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
           invalidation: /
           delete-removed: true
-          no-cache: false
           private: true


### PR DESCRIPTION
Since the access tokens are not available on PR builds, it's better to checkout the latest branding folder only when deploying. Therefore, the workflow has been changed such that one does only testing, another then creates a prod build and a third finally deploys the prod build.