### PR TITLE
Convert ConfirmButton to functional component

### DIFF
--- a/src/app/components/ConfirmButton/index.tsx
+++ b/src/app/components/ConfirmButton/index.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useState } from "react";
 import { Button, Confirm, ButtonProps, Popup } from "semantic-ui-react";
 
 interface IProps {
@@ -13,115 +14,88 @@ interface IProps {
   // This is good for delete buttons, where the ConfirmButton will be removed from the DOM on success anyways.
   // By default is false.
   stopSpinnerOnCompletion?: boolean;
+  children?: React.ReactNode;
 }
 
-interface IState {
-  show: boolean;
-  doing: boolean;
-  error?: string;
-}
+const ConfirmButton = (props: IProps): JSX.Element => {
+  const [show, setShow] = useState<boolean>(false);
+  const [doing, setDoing] = useState<boolean>(false);
+  const [error, setError] = useState<string>(null);
 
-class ConfirmButton extends React.Component<IProps, IState> {
-  constructor(props) {
-    super(props);
-    this.state = {
-      show: false,
-      doing: false,
-      error: null,
-    };
-    this.show = this.show.bind(this);
-    this.handleCancel = this.handleCancel.bind(this);
-    this.handleConfirm = this.handleConfirm.bind(this);
-  }
+  const {
+    onCancel,
+    onConfirm,
+    stopSpinnerOnCompletion,
+    promptText,
+    confirmText,
+    cancelText,
+  } = props;
 
-  private show() {
-    this.setState({
-      show: true,
-      doing: this.state.doing,
-      error: this.state.error,
-    });
-  }
+  const handleCancel = () => {
+    setShow(false);
+    onCancel?.();
+  };
 
-  private handleCancel() {
-    this.setState({
-      show: false,
-      doing: this.state.doing,
-      error: this.state.error,
-    });
-    if (this.props.onCancel) {
-      this.props.onCancel();
-    }
-  }
-
-  private handleConfirm() {
-    this.setState({
-      show: false,
-      doing: true,
-      error: null,
-    });
-    this.props
-      .onConfirm()
+  const handleConfirm = () => {
+    setShow(false);
+    setDoing(true);
+    setError(null);
+    onConfirm?.()
       .then(() => {
-        if (this.props.stopSpinnerOnCompletion !== true) {
+        if (stopSpinnerOnCompletion !== true) {
           return;
         }
-        this.setState({
-          show: this.state.show,
-          doing: false,
-          error: null,
-        });
+        setDoing(false);
+        setError(null);
       })
       .catch((e: Error) => {
-        this.setState({
-          show: this.state.show,
-          doing: false,
-          error: e.message,
-        });
+        setDoing(false);
+        setError(e.message);
       });
-  }
+  };
 
-  public render() {
-    let tooltip: string | null = null;
-    let buttonProps = this.props.buttonProps || {};
-    if (this.props.tooltip) {
-      tooltip = this.props.tooltip;
-    }
-    if (this.state.doing) {
-      buttonProps = {
-        ...buttonProps,
-        loading: true,
-        disabled: true,
-      };
-    }
-    if (this.state.error) {
-      buttonProps = {
-        ...buttonProps,
-        negative: true,
-      };
-      tooltip = this.state.error;
-    }
-    const inner = (
-      <span>
-        <Button onClick={this.show} {...buttonProps}>
-          {this.props.children}
-        </Button>
-        <Confirm
-          open={this.state.show}
-          onCancel={this.handleCancel}
-          onConfirm={this.handleConfirm}
-          content={this.props.promptText}
-          confirmButton={this.props.confirmText}
-          cancelButton={this.props.cancelText}
-        />
-      </span>
-    );
+  const tooltip: string | null = error == null ? props.tooltip : error;
 
-    if (tooltip !== null) {
-      return <Popup trigger={inner} content={tooltip} />;
-    } else {
-      return inner;
-    }
+  let buttonProps = props.buttonProps || {};
+  if (doing) {
+    buttonProps = {
+      ...buttonProps,
+      loading: true,
+      disabled: true,
+    };
   }
-}
+  if (error != null) {
+    buttonProps = {
+      ...buttonProps,
+      negative: true,
+    };
+  }
+  const inner = (
+    <span>
+      <Button
+        onClick={() => {
+          setShow(true);
+        }}
+        {...buttonProps}
+      >
+        {props.children}
+      </Button>
+      <Confirm
+        open={show}
+        onCancel={handleCancel}
+        onConfirm={handleConfirm}
+        content={promptText}
+        confirmButton={confirmText}
+        cancelButton={cancelText}
+      />
+    </span>
+  );
+
+  if (tooltip !== null) {
+    return <Popup trigger={inner} content={tooltip} />;
+  } else {
+    return inner;
+  }
+};
 
 export { ConfirmButton };


### PR DESCRIPTION
This is to modernise the component where we can use hooks, which results in a smaller function and a smaller bundle size.