### PR TITLE
Do not show export image button on Status Report if the radar chart does not render 

### DIFF
--- a/src/app/components/RadarChart/index.tsx
+++ b/src/app/components/RadarChart/index.tsx
@@ -10,6 +10,8 @@ import "./style.less";
 interface IProp {
   data?: RadarData;
   aggregation?: Aggregation;
+  onSuccess?: () => void;
+  onError?: () => void;
 }
 
 export interface IOutcomeGraphPoint {
@@ -98,9 +100,11 @@ const RadarChart = (p: IProp): JSX.Element => {
 
   const noAxis = getNumberOfAxis(p.data.series);
   if (noAxis < 3) {
+    p.onError?.();
     return wrapper(renderError());
   }
 
+  p.onSuccess?.();
   return wrapper(
     <Chart
       config={getConfig(

--- a/src/app/components/ServiceReport/radar.tsx
+++ b/src/app/components/ServiceReport/radar.tsx
@@ -18,6 +18,8 @@ interface IProp {
   serviceReport: IAnswerAggregationReport;
   questionSet: IOutcomeSet;
   category?: boolean;
+  onSuccess?: () => void;
+  onError?: () => void;
 }
 
 function getRadarSeries(
@@ -111,7 +113,14 @@ function renderRadar(t: (text: string) => string, p: IProp): JSX.Element {
   }
   const data = getRadarData(t, p);
   const agg = p.category ? Aggregation.CATEGORY : Aggregation.QUESTION;
-  return <RadarChart data={data} aggregation={agg} />;
+  return (
+    <RadarChart
+      data={data}
+      aggregation={agg}
+      onError={p.onError}
+      onSuccess={p.onSuccess}
+    />
+  );
 }
 
 export const ServiceReportRadar = (p: IProp): JSX.Element => {

--- a/src/app/components/StatusReport/index.tsx
+++ b/src/app/components/StatusReport/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { getStatusReport, IStatusReport } from "apollo/modules/reports";
 import { getOutcomeSet, IOutcomeResult } from "apollo/modules/outcomeSets";
 import { StatusReportRadar } from "./radar";
@@ -50,6 +50,9 @@ const exportReportData = (urlConn: IURLConnector, p: IReportOptions): void => {
 };
 
 const StatusReportInner = (p: IProp) => {
+  const [showCanvasDownloadButton, setShowCanvasDownloadButton] =
+    useState<boolean>(true);
+
   const renderVis = (): JSX.Element => {
     if (p.vis === Visualisation.RADAR) {
       return (
@@ -57,6 +60,12 @@ const StatusReportInner = (p: IProp) => {
           statusReport={p.statusReport.getStatusReport}
           questionSet={p.data.getOutcomeSet}
           category={p.agg === Aggregation.CATEGORY}
+          onError={() => {
+            setShowCanvasDownloadButton(false);
+          }}
+          onSuccess={() => {
+            setShowCanvasDownloadButton(true);
+          }}
         />
       );
     }
@@ -97,7 +106,9 @@ const StatusReportInner = (p: IProp) => {
       <VizControlPanel
         canCategoryAg={p.isCategoryAgPossible}
         visualisations={allowedVisualisations}
-        allowCanvasSnapshot={p.isCanvasSnapshotPossible}
+        allowCanvasSnapshot={
+          p.isCanvasSnapshotPossible && showCanvasDownloadButton
+        }
         export={exportReport}
       />
       {renderVis()}

--- a/src/app/components/StatusReport/radar.tsx
+++ b/src/app/components/StatusReport/radar.tsx
@@ -22,6 +22,8 @@ interface IProp {
   statusReport: ILatestAggregationReport;
   questionSet: IOutcomeSet;
   category?: boolean;
+  onSuccess?: () => void;
+  onError?: () => void;
 }
 
 function getRadarSeries(
@@ -105,7 +107,14 @@ function renderRadar(t: (text: string) => string, p: IProp): JSX.Element {
   }
   const data = getRadarData(t, p);
   const agg = p.category ? Aggregation.CATEGORY : Aggregation.QUESTION;
-  return <RadarChart data={data} aggregation={agg} />;
+  return (
+    <RadarChart
+      data={data}
+      aggregation={agg}
+      onError={p.onError}
+      onSuccess={p.onSuccess}
+    />
+  );
 }
 
 export const StatusReportRadar = (p: IProp): JSX.Element => {


### PR DESCRIPTION
This change adds logic in the main `RadarChart` component to pass in callbacks in cases of a successful render vs. an error in rendering (e.g. when we need certain conditions to be fulfilled). This is then passed upwards to our `StatusReport` component, where set our `showCanvasDownloadButton` state - this is used in conjuction with `isCanvasSnapshotPossible` to determine if we should show the export image button.

#807