### PR TITLE
Fix sequences with no destination

### DIFF
--- a/src/app/components/SequenceForm/index.tsx
+++ b/src/app/components/SequenceForm/index.tsx
@@ -190,6 +190,7 @@ export const SequenceForm = (p: IProps): JSX.Element => {
                 return t("Destination should be a valid web address");
               }
             },
+            setValueAs: (v: string) => (v.length === 0 ? undefined : v),
           })}
         />
       </FormField>


### PR DESCRIPTION
Closes #814. If a destination wasn't provided, it was saving an empty string as the destination; this then resulted in an empty page being shown to beneficiaries after completing the sequence.