### PR TITLE
More ways to create a new record

### DIFF
--- a/src/app/components/ActivityFeed/index.tsx
+++ b/src/app/components/ActivityFeed/index.tsx
@@ -2,9 +2,14 @@ import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { RecordFilter } from "components/RecordFilter";
 import { ActivityFeedEntries, IFeedFilters } from "./feed";
+import { Button, Responsive } from "semantic-ui-react";
+import { useNavigator } from "redux/modules/url";
+import { TooltipButton } from "components/TooltipButton";
 
 export const ActivityFeed = (): JSX.Element => {
   const { t } = useTranslation();
+  const setURL = useNavigator();
+
   const [filters, setFilters] = useState<IFeedFilters>();
   const [it, setIt] = useState<number>(0);
   const onChange = (
@@ -16,9 +21,34 @@ export const ActivityFeed = (): JSX.Element => {
     setFilters({ bens, questionnaires, users, tags });
     setIt(it + 1);
   };
+
+  const newRecord = () => {
+    setURL("/record");
+  };
+
   return (
     <div>
       <div>
+        <span className="title-holder">
+          <Responsive
+            as={Button}
+            minWidth={620}
+            icon="plus"
+            content={t("New Record")}
+            primary={true}
+            onClick={newRecord}
+          />
+          <Responsive
+            as={TooltipButton}
+            maxWidth={619}
+            buttonProps={{
+              icon: "plus",
+              primary: true,
+              onClick: newRecord,
+            }}
+            tooltipContent={t("New Record")}
+          />
+        </span>
         <h1>{t("Activity")}</h1>
         <RecordFilter onChange={onChange} />
       </div>

--- a/src/app/components/QuestionnaireList/item.tsx
+++ b/src/app/components/QuestionnaireList/item.tsx
@@ -3,6 +3,7 @@ import { Icon, List } from "semantic-ui-react";
 import { ConfirmButton } from "components/ConfirmButton";
 import { TooltipIcon } from "components/TooltipIcon";
 import { useTranslation } from "react-i18next";
+import { TooltipButton } from "components/TooltipButton";
 
 interface IProps {
   id: string;
@@ -10,17 +11,27 @@ interface IProps {
   description: string;
   onDelete: () => Promise<void>;
   onNavigate: () => void;
+  onGenLink: () => void;
   readOnly?: boolean; // defaults to false
 }
 
 export const GenericQuestionnaireListItem = (p: IProps): JSX.Element => {
   const { t } = useTranslation();
+
   return (
     <List.Item className="questionnaire" key={p.id}>
       <List.Content floated="right">
+        <TooltipButton
+          tooltipContent={t("Generate beneficiary link")}
+          buttonProps={{
+            icon: "linkify",
+            compact: true,
+            onClick: p.onGenLink,
+          }}
+        />
         {p.readOnly !== true && (
           <ConfirmButton
-            buttonProps={{ icon: true }}
+            buttonProps={{ icon: true, compact: true }}
             promptText={t(
               `Are you sure you want to delete '{questionnaireName}'?`,
               {

--- a/src/app/components/SequenceForm/index.tsx
+++ b/src/app/components/SequenceForm/index.tsx
@@ -190,7 +190,7 @@ export const SequenceForm = (p: IProps): JSX.Element => {
                 return t("Destination should be a valid web address");
               }
             },
-            setValueAs: (v: string) => (v.length === 0 ? undefined : v),
+            setValueAs: (v: string) => (v && v?.length > 0 ? v : undefined),
           })}
         />
       </FormField>

--- a/src/app/containers/Home/index.tsx
+++ b/src/app/containers/Home/index.tsx
@@ -1,54 +1,23 @@
 import * as React from "react";
-import { Responsive, Button } from "semantic-ui-react";
-import { IURLConnector, UrlHOC } from "../../redux/modules/url";
 import { OnboardingChecklist } from "components/OnboardingChecklist";
 import { MinimalPageWrapperHoC } from "components/PageWrapperHoC";
-import { useTranslation } from "react-i18next";
 import { ActivityFeed } from "components/ActivityFeed";
-import "./style.less";
 import { ApolloLoaderHoC } from "components/ApolloLoaderHoC";
 import { getRecentMeetings, IGetRecentMeetings } from "apollo/modules/meetings";
-import { TooltipButton } from "components/TooltipButton";
+import "./style.less";
 
-interface IProps extends IURLConnector {
+interface IProps {
   data?: IGetRecentMeetings;
 }
 
 const HomeInner = (p: IProps): JSX.Element => {
-  const { t } = useTranslation();
-
-  const newRecord = () => {
-    p.setURL("/record");
-  };
   const recordCount = p?.data?.getRecentMeetings?.meetings?.length;
   return (
     <div>
-      <div>
-        <span className="title-holder">
-          <Responsive
-            as={Button}
-            minWidth={620}
-            icon="plus"
-            content={t("New Record")}
-            primary={true}
-            onClick={newRecord}
-          />
-          <Responsive
-            as={TooltipButton}
-            maxWidth={619}
-            buttonProps={{
-              icon: "plus",
-              primary: true,
-              onClick: newRecord,
-            }}
-            tooltipContent={t("New Record")}
-          />
-        </span>
-        <OnboardingChecklist
-          dismissible={recordCount > 0}
-          forceDismiss={recordCount > 8}
-        />
-      </div>
+      <OnboardingChecklist
+        dismissible={recordCount > 0}
+        forceDismiss={recordCount > 8}
+      />
       {recordCount > 0 && <ActivityFeed />}
     </div>
   );
@@ -64,5 +33,4 @@ const HomeWithSpinner = ApolloLoaderHoC<IProps>(
 export const HomeWithData = getRecentMeetings<IProps>({})(HomeWithSpinner);
 
 // t("Home")
-const homeWithPageWrapper = MinimalPageWrapperHoC("Home", "home", HomeWithData);
-export const Home = UrlHOC(homeWithPageWrapper);
+export const Home = MinimalPageWrapperHoC("Home", "home", HomeWithData);

--- a/src/app/containers/Questionnaires/questionnaire.tsx
+++ b/src/app/containers/Questionnaires/questionnaire.tsx
@@ -6,6 +6,8 @@ import {
   IOutcomeMutation,
 } from "apollo/modules/outcomeSets";
 import { GenericQuestionnaireListItem } from "components/QuestionnaireList/item";
+import { QuestionnaireKey } from "models/pref";
+import { useSetPreference } from "redux/modules/pref";
 
 interface IProps extends IOutcomeMutation {
   questionnaire: IOutcomeSet;
@@ -14,12 +16,21 @@ interface IProps extends IOutcomeMutation {
 const QuestionnaireItemInner = (p: IProps): JSX.Element => {
   const q = p.questionnaire;
   const setURL = useNavigator();
+  const setPref = useSetPreference();
 
-  const navigate = () => setURL(`/questions/${q.id}`);
+  const navigate = () => {
+    setPref(QuestionnaireKey, q.id);
+    setURL(`/questions/${q.id}`);
+  };
 
   const onDelete = (): Promise<void> => {
     return p.deleteQuestionSet(q.id).then();
     // errors and success handled by ConfirmButton
+  };
+
+  const onGenLink = () => {
+    setPref(QuestionnaireKey, q.id);
+    setURL("/record/remote");
   };
 
   return (
@@ -30,6 +41,7 @@ const QuestionnaireItemInner = (p: IProps): JSX.Element => {
       onDelete={onDelete}
       onNavigate={navigate}
       readOnly={q.readOnly}
+      onGenLink={onGenLink}
     />
   );
 };

--- a/src/app/containers/Sequences/sequence.tsx
+++ b/src/app/containers/Sequences/sequence.tsx
@@ -3,6 +3,8 @@ import { ISequence } from "models/sequence";
 import { useNavigator } from "redux/modules/url";
 import { GenericQuestionnaireListItem } from "components/QuestionnaireList/item";
 import { deleteSequence, IDeleteSequence } from "apollo/modules/sequence";
+import { useSetPreference } from "redux/modules/pref";
+import { QuestionnaireKey } from "models/pref";
 
 interface IProps {
   sequence: ISequence;
@@ -11,11 +13,20 @@ interface IProps {
 const SequenceItemInner = (p: IProps & IDeleteSequence): JSX.Element => {
   const s = p.sequence;
   const setURL = useNavigator();
+  const setPref = useSetPreference();
 
-  const navigate = () => setURL(`/sequences/${s.id}`);
+  const navigate = () => {
+    setPref(QuestionnaireKey, s.id);
+    setURL(`/sequences/${s.id}`);
+  };
 
   const onDelete = (): Promise<void> => {
     return p.deleteSequence(p.sequence.id);
+  };
+
+  const onGenLink = () => {
+    setPref(QuestionnaireKey, s.id);
+    setURL("/record/remote");
   };
 
   let desc = "";
@@ -37,6 +48,7 @@ const SequenceItemInner = (p: IProps & IDeleteSequence): JSX.Element => {
       description={desc}
       onDelete={onDelete}
       onNavigate={navigate}
+      onGenLink={onGenLink}
     />
   );
 };


### PR DESCRIPTION
Adds a generate link button against questionnaires and ensures the new record button is more often visible on the home page. Towards #819